### PR TITLE
Add support for printing module source code

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,1 @@
-from src.pysource import get_callable, print_source
+from src.pysource import get_object, print_source

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1,6 +1,6 @@
 import argparse
 
-from src.pysource import get_callable, print_source
+from src.pysource import get_object, print_source
 
 
 def main():
@@ -11,8 +11,8 @@ def main():
                         help='page output (like Unix more command)')
     args = parser.parse_args()
 
-    func = get_callable(args.module)
-    print_source(func, pager=args.use_pager)
+    obj = get_object(args.module)
+    print_source(obj, pager=args.use_pager)
 
 
 if __name__ == '__main__':

--- a/src/pysource.py
+++ b/src/pysource.py
@@ -4,9 +4,12 @@ import pydoc
 
 
 def get_callable(arg):
-    module_str, name = arg.rsplit(".", 1)
-    module = importlib.import_module(module_str)
-    return getattr(module, name)
+    module_str, sep, name = arg.rpartition(".")
+    if sep:
+        module = importlib.import_module(module_str)
+        return getattr(module, name)
+    else:
+        return importlib.import_module(name)
 
 
 def print_source(func, pager=False):

--- a/src/pysource.py
+++ b/src/pysource.py
@@ -3,7 +3,7 @@ import inspect
 import pydoc
 
 
-def get_callable(arg):
+def get_object(arg):
     module_str, sep, name = arg.rpartition(".")
     if sep:
         module = importlib.import_module(module_str)

--- a/tests/test_pysource.py
+++ b/tests/test_pysource.py
@@ -1,3 +1,4 @@
+import collections
 from inspect import getsource
 from os.path import join
 from pathlib import PurePath
@@ -13,6 +14,7 @@ from src import get_callable, print_source
     ("random.sample", sample),
     ("pathlib.PurePath", PurePath),
     ("os.path.join", join),
+    ("collections", collections),
 ])
 def test_get_callable(arg, expected):
     assert get_callable(arg) is expected

--- a/tests/test_pysource.py
+++ b/tests/test_pysource.py
@@ -7,7 +7,7 @@ from random import sample, choice
 
 import pytest
 
-from src import get_callable, print_source
+from src import get_object, print_source
 
 
 @pytest.mark.parametrize("arg, expected", [
@@ -16,8 +16,8 @@ from src import get_callable, print_source
     ("os.path.join", join),
     ("collections", collections),
 ])
-def test_get_callable(arg, expected):
-    assert get_callable(arg) is expected
+def test_get_object(arg, expected):
+    assert get_object(arg) is expected
 
 
 @pytest.mark.parametrize("func", [


### PR DESCRIPTION
Now it'll accept "collections", "os", "collections.abc", and other whole modules.

The last commit renames `get_callable` to `get_object` (since modules aren't callables). Feel free to remove that commit if you prefer to maintain the existing name.